### PR TITLE
Scraping the100.io game gamertags from game link.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,5 +18,7 @@ require('./scripts/drsQueue.service.js');
 require('./scripts/drsSettings.controller.js');
 require('./scripts/drsSettings.service.js');
 require('./scripts/drsUtilities.service.js');
+require('./scripts/drsThe100.service.js');
+
 
 require('./scss/main.scss');

--- a/app/scripts/drsInputPlayer.directive.js
+++ b/app/scripts/drsInputPlayer.directive.js
@@ -53,7 +53,7 @@ function InputPlayerCtrl($rootScope, Constants, PlayerListService, SettingsServi
         vm.t100s.scrapeGamertags(gameId)
             .then((function (tags) {
                 tags.forEach(t => {
-                    vm.ls.addPlayer(t, platform)
+                    vm.pl.addPlayer(t, platform)
                 })
                 vm.player = "";
             }))

--- a/app/scripts/drsInputPlayer.directive.js
+++ b/app/scripts/drsInputPlayer.directive.js
@@ -16,21 +16,48 @@ function InputPlayer() {
   return directive;
 }
 
-InputPlayerCtrl.$inject = ['$rootScope', 'Constants', 'PlayerListService', 'SettingsService'];
+InputPlayerCtrl.$inject = ['$rootScope', 'Constants', 'PlayerListService', 'SettingsService', 'The100Service'];
 
-function InputPlayerCtrl($rootScope, Constants, PlayerListService, SettingsService) {
+function InputPlayerCtrl($rootScope, Constants, PlayerListService, SettingsService, The100Service) {
   const vm = this;
 
   angular.extend(vm, {
     pl: PlayerListService,
-    ss: SettingsService
+    ss: SettingsService,
+    t100s: The100Service
   });
 
-  vm.add = add;
+  vm.run = run;
   vm.player = "";
   vm.keyup = keyup;
   vm.toggle = toggle;
   vm.platform = getPlatformFromSettings();
+
+    function run() {
+        var input = vm.player;
+
+        var match;
+        match = input.match(/the100\.io\/game\/([0-9]+)$/)
+
+        if (match === null) {
+            return add();
+        } else {
+            return the100(match[1]);
+        }
+    }
+
+    function the100(gameId) {
+
+        const platform = vm.platform ? Constants.platforms[1] : Constants.platforms[0];
+
+        vm.t100s.scrapeGamertags(gameId)
+            .then((function (tags) {
+                tags.forEach(t => {
+                    vm.ls.addPlayer(t, platform)
+                })
+                vm.player = "";
+            }))
+    }
 
   function add() {
     const platform = vm.platform ? Constants.platforms[1] : Constants.platforms[0];
@@ -51,7 +78,7 @@ function InputPlayerCtrl($rootScope, Constants, PlayerListService, SettingsServi
 
   function keyup(event) {
     if (event.keyCode === 13) {
-      vm.add();
+      vm.run();
     }
   }
 

--- a/app/scripts/drsInputPlayer.directive.js
+++ b/app/scripts/drsInputPlayer.directive.js
@@ -34,10 +34,9 @@ function InputPlayerCtrl($rootScope, Constants, PlayerListService, SettingsServi
   vm.platform = getPlatformFromSettings();
 
     function run() {
-        var input = vm.player;
+        const input = vm.player;
 
-        var match;
-        match = input.match(/the100\.io\/game\/([0-9]+)$/)
+        const match = input.match(/the100\.io\/game\/([0-9]+)$/)
 
         if (match === null) {
             return add();

--- a/app/scripts/drsInputPlayer.template.html
+++ b/app/scripts/drsInputPlayer.template.html
@@ -8,5 +8,5 @@
     <p translate="{{'Xbox.Service'}}"></p>
   </div>
   <input id="gamer-tag" type="text" ng-model="vm.player" ng-keyup="vm.keyup($event)" translate-attr="{placeholder: (vm.platform ? 'Xbox.Player' : 'PlayStation.Player')}" maxlength="64" ng-trim="false">
-  <span id="submit" ng-click="vm.add()"><i class="fa fa-search"></i></span>
+  <span id="submit" ng-click="vm.run()"><i class="fa fa-search"></i></span>
 </span>

--- a/app/scripts/drsThe100.service.js
+++ b/app/scripts/drsThe100.service.js
@@ -4,23 +4,19 @@ angular
     .module('drsApp')
     .factory('The100Service', The100Service);
 
-The100Service.$inject = ['$q', '$http', '$sce'];
+The100Service.$inject = ['$http'];
 
 var the100endpoint = $DRS_100_ENDPOINT;
 
-function The100Service($q, $http, $sce) {
+function The100Service($http) {
 
     const service = {
         scrapeGamertags: scrapeGamertags,
     };
     return service;
 
-
     function scrapeGamertags(gameId) {
-
-        var url = the100endpoint + gameId;
-
-        const p = $q.defer();
+        const url = the100endpoint + gameId;
 
         return $http.get(url).then(function (data) {
             return data.data;

--- a/app/scripts/drsThe100.service.js
+++ b/app/scripts/drsThe100.service.js
@@ -1,0 +1,31 @@
+import angular from 'angular';
+
+angular
+    .module('drsApp')
+    .factory('The100Service', The100Service);
+
+The100Service.$inject = ['$q', '$http', '$sce'];
+
+var the100endpoint = $DRS_100_ENDPOINT;
+
+function The100Service($q, $http, $sce) {
+
+    const service = {
+        scrapeGamertags: scrapeGamertags,
+    };
+    return service;
+
+
+    function scrapeGamertags(gameId) {
+
+        var url = the100endpoint + gameId;
+
+        const p = $q.defer();
+
+        return $http.get(url).then(function (data) {
+            return data.data;
+        }).catch(function (data) {
+            console.error(data)
+        });
+    }
+}

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -12,8 +12,8 @@ const NotifyPlugin = require('notify-webpack-plugin');
 const ASSET_NAME_PATTERN = 'static/[name]-[hash:6].[ext]';
 
 const packageJson = require('../package.json');
-const apiKeyJson = require('../apiKey.json');
-// const apiKeyJson = require('../apiKey_server.json');
+const configJson = require('../apiKey.json');
+//const configJson = require('../apiKey_server.json');
 const nodeModulesDir = path.join(__dirname, '../node_modules');
 
 // https://github.com/dmachat/angular-webpack-cookbook/wiki/Optimizing-Development
@@ -25,7 +25,8 @@ const preMinifiedDeps = [
 module.exports = (env) => {
   const isDev = env === 'dev';
   const version = packageJson.version.toString();
-  const apiKey = apiKeyJson.apiKey.toString();
+  const apiKey = configJson.apiKey.toString();
+  const the100Endpoint = configJson.the100endpoint || 'http://destinyraidstatus.com/api/the100/game/';
 
   const config = {
     entry: {
@@ -137,7 +138,8 @@ module.exports = (env) => {
       new webpack.DefinePlugin({
         $DRS_VERSION: JSON.stringify(version),
         $DRS_FLAVOR: JSON.stringify(env),
-        $DRS_API_KEY: JSON.stringify(apiKey)
+        $DRS_API_KEY: JSON.stringify(apiKey),
+        $DRS_100_ENDPOINT: JSON.stringify(the100Endpoint)
       }),
 
       // Enable if you want to debug the size of the chunks

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,20 @@
+var app = require('express')();
+var cors = require('cors');
+var axios = require('axios');
+var cheerio = require('cheerio');
+
+app.use(cors('*'));
+
+app.get('/api/the100/game/:game', function(req, res) {
+    axios.get(`https://www.the100.io/game/${req.params.game}`)
+    .then(function(response) {
+        var $ = cheerio.load(response.data)
+        var gamertags = $('.gamertag a').map(function() { return $(this).text(); }).get();
+        res.json(gamertags);
+    })
+    .catch(function() {
+        res.json([])
+    })
+});
+
+app.listen(3000);

--- a/server/index.js
+++ b/server/index.js
@@ -17,4 +17,4 @@ app.get('/api/the100/game/:game', function(req, res) {
     })
 });
 
-app.listen(3000);
+app.listen(process.env.PORT || 3000);

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.16.1",
+    "cheerio": "^0.22.0",
+    "cors": "^2.8.3",
+    "express": "^4.15.2"
+  }
+}


### PR DESCRIPTION
Summary of changes:

The Gamertag input is now an 'omnisearch' - it will recognise the100.io game link (`https://www.the100.io/game/967740`), regex match the game id and run a scrape against the100.io to get all gamertags. Once those are received it will add them in a loop reusing the `vm.add()` method that already existed.

One annoying factor is that because of cors and mime checking settings, there is no way to directly scrape the100.io from the browser, a server side component is needed.

This component is provided in `server/index.js` and has it's own `package.json`, will need to be installed and then ran (preferably using something like nodemon or pm2). By default it will bind itself to `:3000`

There's also been a change to cofig, the `apiKey.json` file now contains the100endpoint to look for a game (this is mostly for development, I will explain that below).

#### So, how to deploy it all together?

1. Client code / Extension

Nothing changes here, the current README instructions are still applicable, just build dist and chuck it out.

2. Server code

This needs to be put in a place where you want to run it, `npm installed` and then `node run`. By default it will be on port 3000, but you can control it with `process.env.PORT`

You will then need to provide a proxyPass directive to your apache config, by default the client code is expecting to find info about gamertags under `http://destinyraidstatus.com/api/the100/game/:game` so what we want to do is make all requests to `http://destinyraidstatus.com/api/` to proxy to our node server process.

Not sure how you have everything configured, but following should be a good start (assuming you are running that server component on port 3000):

https://httpd.apache.org/docs/2.4/mod/mod_proxy.html

```
ProxyPass "/api" "http://127.0.0.1:3000/"
```

So we are simply looking at proxying a call from the client (`http://destinyraidstatus.com/api/the100/game/123123`) into a call that will go into our server component (`http://localhost:3000/api/the100/game/:game`), ProxyPass should do just this.

#### For development?

Here you just need to run the server component locally and then change apiKey.json and add that endpoint parameter to point to localhost, example below

```
{ "apiKey": "", "the100endpoint": "http://127.0.0.1:3000/api/the100/game/" }
```

That should be all you need.


[example](https://dl.dropboxusercontent.com/content_link/dQszVTP1M6qrhOMq0xl3ICveTxu7wRGZT6qLN29S1SqAxEksgpAtSwiKHksBZjSG/file)



